### PR TITLE
Allow SuperPoint_Open weights to be loaded from local cache

### DIFF
--- a/gluefactory/models/extractors/superpoint_open.py
+++ b/gluefactory/models/extractors/superpoint_open.py
@@ -7,6 +7,7 @@
 """
 
 from collections import OrderedDict
+from pathlib import Path
 from types import SimpleNamespace
 
 import torch
@@ -85,6 +86,7 @@ class SuperPoint(BaseModel):
         "descriptor_dim": 256,
         "channels": [64, 64, 128, 128, 256],
         "dense_outputs": None,
+        "weights": None,  # local path of pretrained weights
     }
 
     checkpoint_url = "https://github.com/rpautrat/SuperPoint/raw/master/weights/superpoint_v6_from_tf.pth"  # noqa: E501
@@ -112,7 +114,10 @@ class SuperPoint(BaseModel):
             VGGBlock(c, self.conf.descriptor_dim, 1, relu=False),
         )
 
-        state_dict = torch.hub.load_state_dict_from_url(self.checkpoint_url)
+        if conf.weights is not None and Path(conf.weights).exists():
+            state_dict = torch.load(conf.weights, map_location="cpu")
+        else:
+            state_dict = torch.hub.load_state_dict_from_url(self.checkpoint_url)
         self.load_state_dict(state_dict)
 
     def _forward(self, data):


### PR DESCRIPTION
Hello,
This PR addresses an issue we encounter when having to use SuperPoint in a production environment.
Currently, the pre-trained model weights MUST be downloaded from `https://github.com/rpautrat/SuperPoint/raw/master/weights/superpoint_v6_from_tf.pth`. 

This is not compatible with a production env:
- You don't necessarily want your model to access internet
- GitHub could be down for a moment, thus your endpoint could be down as well
- Rémi Pautrat could rename / delete that file, just to watch the world burn 😄

This PR allows the users to specify a `weights` parameter in the config input (similar to `LightGlue`), so that the weights are loaded from cache instead of from `rpautrat`'s repo.