### PR TITLE
Fix DISK extraction.

### DIFF
--- a/gluefactory/models/extractors/disk_kornia.py
+++ b/gluefactory/models/extractors/disk_kornia.py
@@ -59,12 +59,12 @@ class DISK(BaseModel):
         for i in range(0, image.shape[0], chunk):
             if self.conf.dense_outputs:
                 features, d_descriptors = self._get_dense_outputs(
-                    image[: min(image.shape[0], i + chunk)]
+                    image[i: min(image.shape[0], i + chunk)]
                 )
                 dense_descriptors.append(d_descriptors)
             else:
                 features = self.model(
-                    image[: min(image.shape[0], i + chunk)],
+                    image[i: min(image.shape[0], i + chunk)],
                     n=self.conf.max_num_keypoints,
                     window_size=self.conf.nms_window_size,
                     score_threshold=self.conf.detection_threshold,


### PR DESCRIPTION
There is a typo with the DISK+Kornia extraction process which causes DISK+LG training fail.  It is related to using chunk during the extraction process.   

The fix is quite straightforward.

It also has been reported by https://github.com/cvg/glue-factory/issues/72

@sarlinpe @Phil26AT @aduverger