### PR TITLE
Fix ALIKED scaling (now similar to LG repo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Here are the results as Area Under the Curve (AUC) of the pose error at  5/10/20
 | [SuperPoint + LightGlue](gluefactory/configs/superpoint+lightglue-official.yaml) | 56.7 / 72.4 / 83.7 | 51.0 / 68.1 / 80.7 | 66.8 / 79.3 / 87.9 |
 | [SIFT (2K) + LightGlue](gluefactory/configs/sift+lightglue-official.yaml) | ? / ? / ? | 43.5 / 61.5 / 75.9 | 60.4 / 74.3 / 84.5 |
 | [SIFT (4K) + LightGlue](gluefactory/configs/sift+lightglue-official.yaml) | ? / ? / ? | 49.9 / 67.3 / 80.3 | 65.9 / 78.6 / 87.4 |
-| [ALIKED + LightGlue](gluefactory/configs/aliked+lightglue-official.yaml) | ? / ? / ? | 51.5 / 68.1 / 80.4 | 66.3 / 78.7 / 87.5 |
+| [ALIKED + LightGlue](gluefactory/configs/aliked+lightglue-official.yaml) | ? / ? / ? | 52.3 / 68.8 / 81.0 | 66.4 / 79.0 / 87.5 |
 | [SuperPoint + GlueStick](gluefactory/configs/superpoint+lsd+gluestick.yaml) | 53.2 / 69.8 / 81.9 | 46.3 / 64.2 / 78.1 | 64.4 / 77.5 / 86.5 |
 
 </details>

--- a/gluefactory/models/extractors/aliked.py
+++ b/gluefactory/models/extractors/aliked.py
@@ -237,7 +237,7 @@ class DKD(nn.Module):
                 scoredispersitys.append(kptscore)  # for jit.script compatability
                 kptscores.append(kptscore)
 
-        return keypoints, scoredispersitys, kptscores
+        return keypoints, kptscores, scoredispersitys
 
 
 class InputPadder(object):
@@ -770,10 +770,10 @@ class ALIKED(BaseModel):
         keypoints, kptscores, scoredispersitys = self.dkd(
             score_map, image_size=data.get("image_size")
         )
-        descriptors, offsets = self.desc_head(feature_map, keypoints)
+        descriptors, _ = self.desc_head(feature_map, keypoints)
 
         _, _, h, w = image.shape
-        wh = torch.tensor([w, h], device=image.device)
+        wh = torch.tensor([w - 1, h - 1], device=image.device)
         # no padding required,
         # we can set detection_threshold=-1 and conf.max_num_keypoints
         return {


### PR DESCRIPTION
Fixes a small inaccuracy on scaling keypoints in ALIKED. Now it's similar to [ALIKED in the LightGlue repository](https://github.com/cvg/LightGlue/blob/main/lightglue/aliked.py#L751).

This improved results on MegaDepth1500 (updated README).

Also fixed a bug with the keypoint scores in ALIKED (https://github.com/cvg/LightGlue/pull/145).