### PR TITLE
Download Hpatches from official URL (HuggingFace)

### DIFF
--- a/gluefactory/datasets/hpatches.py
+++ b/gluefactory/datasets/hpatches.py
@@ -54,7 +54,7 @@ class HPatches(BaseDataset, torch.utils.data.Dataset):
         "v_astronautis",
         "v_talent",
     )
-    url = "https://www.kaggle.com/api/v1/datasets/download/javidtheimmortal/hpatches-sequence-release"
+    url = "https://huggingface.co/datasets/vbalnt/hpatches/resolve/main/hpatches-sequences-release.zip"
 
     def _init(self, conf):
         assert conf.batch_size == 1
@@ -82,7 +82,7 @@ class HPatches(BaseDataset, torch.utils.data.Dataset):
         zip_path = data_dir / self.url.rsplit("/", 1)[-1]
         torch.hub.download_url_to_file(self.url, zip_path)
         # Open the ZIP file
-        with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+        with zipfile.ZipFile(zip_path, "r") as zip_ref:
             # Extract all contents to a directory
             zip_ref.extractall(data_dir)
 

--- a/gluefactory/datasets/hpatches.py
+++ b/gluefactory/datasets/hpatches.py
@@ -85,6 +85,7 @@ class HPatches(BaseDataset, torch.utils.data.Dataset):
         with zipfile.ZipFile(zip_path, "r") as zip_ref:
             # Extract all contents to a directory
             zip_ref.extractall(data_dir)
+        zip_path.unlink()  # Remove the zip file after extraction
 
     def get_dataset(self, split):
         assert split in ["val", "test"]


### PR DESCRIPTION
The official hpatches dataset was uploaded to huggingface by the authors (https://github.com/hpatches/hpatches-dataset/commit/fd79bca4dc755c9f623a5f129f3452fc663ee305), so I updated the link accordingly.

@Parskatt @rpautrat 