### PR TITLE
Fix estimate_relative_pose bundle_opt argument for poselib>=2.0.4 (#154)

### DIFF
--- a/gluefactory/robust_estimators/relative_pose/poselib.py
+++ b/gluefactory/robust_estimators/relative_pose/poselib.py
@@ -27,6 +27,7 @@ class PoseLibRelativePoseEstimator(BaseEstimator):
                 "max_epipolar_error": self.conf.ransac_th,
                 **OmegaConf.to_container(self.conf.options),
             },
+            {},  # bundle_opt: required as of poselib>=2.0.4, no longer optional in all builds
         )
         success = M is not None
         if success:


### PR DESCRIPTION
Fixes #154. poselib.estimate_relative_pose() was called with only 5 positional args; on poselib builds where bundle_opt is not resolved as optional, this raises a TypeError during overload resolution. Passing an explicit empty bundle_opt dict fixes it. Verified against poselib 2.0.4 and 2.0.5.

Testing: reproduced the failing call signature directly against the compiled poselib extension using the same argument types as this code path (numpy float64 [m,2] point arrays, dict camera params). Confirmed the 6-arg call (with explicit bundle_opt={}) succeeds on both poselib==2.0.4 and poselib==2.0.5, and that `python -m py_compile` passes on the patched file.